### PR TITLE
Add ForceNew property to domain resource (No Update defined)

### DIFF
--- a/resource_domain.go
+++ b/resource_domain.go
@@ -15,10 +15,12 @@ func resourceDomain() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"mail": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 		},
 	}


### PR DESCRIPTION
Hi @takebayashi 

When I use `terraform-provider-dozens` with `terraform v0.5.3`, the following message was displayed:

```
# dozens.tf
provider "dozens" {
        user = "gongo"
        key = "XXXXX"
}

resource "dozens_domain" "gongo_org" {
        name = "gongo.org"
        mail = "gongo@example.com"
}
```

```
$ terraform plan
There are warnings and/or errors related to your configuration. Please
fix these before continuing.

Errors:

  * provider.dozens: Internal validation of the provider failed! This is always a bug
with the provider itself, and not a user issue. Please report
this bug:

dozens_domain: No Update defined, must set ForceNew on: []string{"name", "mail"}
```

This message is displayed from `v0.4.1`. See: https://github.com/hashicorp/terraform/pull/1379
