### PR TITLE
Allow read the record whose `name` is empty

### DIFF
--- a/resource_record.go
+++ b/resource_record.go
@@ -63,12 +63,18 @@ func readRecord(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	name := d.Get("name").(string)
+	fqname := name + "." + domain.Name
+	if name == "" {
+		fqname = domain.Name
+	}
+
 	list, err := client.ListRecords(domain)
 	if err != nil {
 		return err
 	}
+
 	for _, record := range list {
-		if record.FQName == (name + "." + domain.Name) {
+		if record.FQName == fqname {
 			applyRecord(record, d)
 			return nil
 		}


### PR DESCRIPTION
This issue is similar to https://github.com/takebayashi/go-dozens/pull/1

Example:

```
provider "dozens" {
        user = "user"
        key = "key"
}

resource "dozens_domain" "gongo_org" {
        name = "gongo.org"
        mail = "gongo@example.com"
}

resource "dozens_record" "gongo_org" {
        depends_on = "dozens_domain.gongo_org"
        domain     = "gongo.org"
        name       = ""
        address    = "example.com"
        type       = "CNAME"
        ttl        = "7200"
        priority   = ""
}
```

Run `terraform apply`, record of registration has been successful.

```
$ terraform apply
dozens_domain.gongo_org: Creating...
  mail: "" => "gongo@example.com"
  name: "" => "gongo.org"
dozens_domain.gongo_org: Creation complete
dozens_record.gongo_org: Creating...
  address: "" => "example.com"
  domain:  "" => "gongo.org"
  ttl:     "" => "7200"
  type:    "" => "CNAME"
dozens_record.gongo_org: Creation complete

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

![2015-07-04 18 48 57](https://cloud.githubusercontent.com/assets/124713/8507456/ee4cb0be-227e-11e5-959a-273541691865.png)

But, run `terraform plan` immediately after:

```
$ terraform plan
Refreshing Terraform state prior to plan...

dozens_domain.gongo_org: Refreshing state... (ID: 11742)

(snip..)

+ dozens_record.gongo_org
    address: "" => "example.com"
    domain:  "" => "gongo.org"
    ttl:     "" => "7200"
    type:    "" => "CNAME"
```

Registered record that name is empty has not been able to read.
